### PR TITLE
Update func.yml syntax for 0.22.0

### DIFF
--- a/func.yaml
+++ b/func.yaml
@@ -19,7 +19,7 @@ volumes: []
 buildEnvs: []
 envs:
 - name: REDIS_HOST
-  value: 10.200.130.188:6379
+  value: ""
 - name: REDIS_PASSWORD
   value: ""
 annotations: {}

--- a/func.yaml
+++ b/func.yaml
@@ -6,10 +6,7 @@ registry: ""
 image: docker.io/salaboy/start-game:latest
 imageDigest: sha256:766741a632d63c0d8da5ba502aa677e4ab646d49f20c3c5f526e1442dea51de8
 build: local
-git:
-  url: null
-  revision: null
-  contextdir: null
+git: {}
 builder: gcr.io/paketo-buildpacks/builder:base
 builders:
   base: gcr.io/paketo-buildpacks/builder:base

--- a/func.yaml
+++ b/func.yaml
@@ -19,7 +19,7 @@ volumes: []
 buildEnvs: []
 envs:
 - name: REDIS_HOST
-  value: ""
+  value: "" # <hostname>:<port>
 - name: REDIS_PASSWORD
   value: ""
 annotations: {}


### PR DESCRIPTION
It looks like the latest version of the func plugin (0.22.0) complains about the non-string `git` information and doesn't recognize the `contextdir` property. I updated the `func.yaml` file based on how the plugin itself modified it.
